### PR TITLE
Correct the random_seed in ``classify.py''

### DIFF
--- a/src/openne/__main__.py
+++ b/src/openne/__main__.py
@@ -172,7 +172,7 @@ def main(args):
         print("Training classifier using {:.2f}% nodes...".format(
             args.clf_ratio*100))
         clf = Classifier(vectors=vectors, clf=LogisticRegression())
-        clf.split_train_evaluate(X, Y, args.clf_ratio)
+        clf.split_train_evaluate(X, Y, args.clf_ratio, seed=0)
 
 
 if __name__ == "__main__":

--- a/src/openne/classify.py
+++ b/src/openne/classify.py
@@ -51,7 +51,7 @@ class Classifier(object):
         Y = self.clf.predict(X_, top_k_list=top_k_list)
         return Y
 
-    def split_train_evaluate(self, X, Y, train_precent, seed=0):
+    def split_train_evaluate(self, X, Y, train_precent, seed=None):
         state = numpy.random.get_state()
 
         training_size = int(train_precent * len(X))


### PR DESCRIPTION
The random_seed in ``classify.py'' (def split_train_evaluate) was 0 as the default parameter, which is not reasonable in practice. It could be set in ``__main__.py'', otherwise the model would be all the same. 